### PR TITLE
Add known ransomware fields

### DIFF
--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -261,6 +261,8 @@ Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
 - `_id` [string]: [Common Vulnerabilities and
   Exposures](https://cve.mitre.org/)
   identifier for a Known Exploited Vulnerability (KEV)
+- `known_ransomware` [boolean]: Is the vulnerability in this KEV known
+  to have been leveraged as part of a ransomware campaign?
 
 ### notifications Collection ###
 
@@ -487,6 +489,9 @@ CyHy stakeholders.
     score](https://nvd.nist.gov/vuln-metrics)
   - `cvss_version` [string]: CVSS version used for the CVSS base score
   - `kev` [boolean]: Is this ticket marked as a Known Exploited Vulnerability (KEV)?
+  - `known_ransomware` [boolean]: Is the vulnerability in this ticket known to
+    have been leveraged as part of a ransomware campaign, according to the
+    [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)?
   - `name` [string]: Vulnerability name
   - `score_source` [string]: Source of the CVSS base score (e.g. "nvd" or
     "nessus")

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -488,7 +488,8 @@ CyHy stakeholders.
   - `cvss_base_score` [decimal]: [CVSS base
     score](https://nvd.nist.gov/vuln-metrics)
   - `cvss_version` [string]: CVSS version used for the CVSS base score
-  - `kev` [boolean]: Is this ticket marked as a Known Exploited Vulnerability (KEV)?
+  - `kev` [boolean]: Is the vulnerability in this ticket a Known Exploited
+    Vulnerability (KEV), according to the [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)?
   - `known_ransomware` [boolean]: Is the vulnerability in this ticket known to
     have been leveraged as part of a ransomware campaign, according to the
     [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)?

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -490,7 +490,7 @@ CyHy stakeholders.
   - `cvss_version` [string]: CVSS version used for the CVSS base score
   - `kev` [boolean]: Is the vulnerability in this ticket a Known Exploited
     Vulnerability (KEV), according to the [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)?
-  - `known_ransomware` [boolean]: Is the vulnerability in this ticket known to
+  - `kev_ransomware` [boolean]: Is the vulnerability in this ticket known to
     have been leveraged as part of a ransomware campaign, according to the
     [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)?
   - `name` [string]: Vulnerability name


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the data dictionary to include the `known_ransomware` fields added in https://github.com/cisagov/cyhy-core/pull/80.  I also took this opportunity to improve the `kev` documentation a bit (see https://github.com/cisagov/ncats-data-dictionary/commit/87ba86f44c1ab3e6f5615f6ba80efdbd56e7e98e).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

What good is documentation if we don't keep it up to date?  Thanks to @mcdonnnj for the [reminder](https://github.com/cisagov/cyhy-core/pull/80#pullrequestreview-1691260471) about this. 👍 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested via visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
