### PR TITLE
Add missing snapshot fields

### DIFF
--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -441,7 +441,7 @@ CyHy stakeholders.
 - `descendants_included` [list of strings]: Identifiers of descendant
   organizations (if any) whose data is included in this snapshot
 - `end_time` [ISO date]: Timestamp indicating when the last scan in this
-   snapshot was completed
+  snapshot was completed
 - `host_count` [integer]: Number of hosts detected in this snapshot
 - `last_change` [ISO date]: Timestamp indicating when this snapshot document
   was last updated

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -446,8 +446,8 @@ CyHy stakeholders.
 - `last_change` [ISO date]: Timestamp indicating when this snapshot document
   was last updated
 - `latest` [boolean]: Is this the latest snapshot for this organization?
-- `networks` [list of strings]: CIDR blocks claimed by the organization
-  at the time this snapshot was generated
+- `networks` [list of strings]: CIDR blocks claimed by the organization (and
+  any included descendants) at the time this snapshot was generated
 - `owner` [string]: Organization that this snapshot is associated with
 - `parents` [ObjectId]: Identifier of the parent snapshot(s); used only
   for organizations with children; if this value is equal to the \_id

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -431,10 +431,15 @@ The data in this collection is derived from IP addresses supplied by the
 CyHy stakeholders.
 
 - `_id` [ObjectId]: Internal database id of this snapshot document
+- `addresses_scanned` [integer]: Number of IP addresses included in this
+  snapshot that have been fully scanned by CyHy at least once, as of the time
+  this snapshot was generated
 - `cvss_average_all` [decimal]: Average CVSS score of all hosts in
   this snapshot
 - `cvss_average_vulnerable` [decimal]: Average CVSS score of
   vulnerable hosts in this snapshot
+- `descendants_included` [list of strings]: Identifiers of descendant
+  organizations (if any) whose data is included in this snapshot
 - `end_time` [ISO date]: Timestamp indicating when the last scan in this
    snapshot was completed
 - `host_count` [integer]: Number of hosts detected in this snapshot
@@ -451,6 +456,11 @@ CyHy stakeholders.
   snapshot
 - `services` [dictionary]: Number of services detected in this snapshot,
   grouped by service name
+- `silent_port_count` [integer]: Total number of ports detected in this snapshot
+  whose service was detected as
+  ["tcpwrapped"](https://secwiki.org/w/FAQ\_tcpwrapped), indicating that a full
+  TCP handshake was completed during port scanning, but the connection was
+  closed before any data was sent
 - `start_time` [ISO date]: Timestamp indicating when the first scan in this
   snapshot was completed
 - `tix_msec_open`[dictionary]: Time a ticket has been open


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds data definitions for three previously-overlooked [snapshot](https://github.com/cisagov/ncats-data-dictionary/blob/develop/NCATS_Data_Dictionary.md#snapshots-collection) fields:
* `addresses_scanned`
* `descendants_included`
* `silent_port_count`

It also improves one existing definition (https://github.com/cisagov/ncats-data-dictionary/commit/d320164a3b96e1d5e3920424b1fc51ef906cc86f) and cleans up a bit of whitespace (https://github.com/cisagov/ncats-data-dictionary/commit/475ada401dfd153d8800a46ec499289189bc50e2).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

@climber-girl pointed out that our data dictionary was incomplete because it was missing the snapshot fields mentioned above.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Markdown was reviewed visually and all automated tests pass.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

